### PR TITLE
Fix deprecated warnings for RN 0.25 or higher

### DIFF
--- a/src/Animated.js
+++ b/src/Animated.js
@@ -1,8 +1,8 @@
-import React from 'react-native';
+import React, { PropTypes } from 'react';
+import ReactNative from 'react-native';
 const {
   Animated,
-  PropTypes
-} = React;
+} = ReactNative;
 
 function createAnimationDongle(className) {
   return React.createClass({

--- a/src/ListView.js
+++ b/src/ListView.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import React from 'react-native';
+import React, { PropTypes } from 'react';
+import ReactNative from 'react-native';
 
 const {
-  PropTypes,
   ListView
-} = React;
+} = ReactNative;
 
 export default React.createClass({
   displayName: 'CycleListView',

--- a/src/Touchable.js
+++ b/src/Touchable.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import React from 'react-native';
+import React, { PropTypes } from 'react';
 import {findHandler} from './driver';
+import ReactNative from 'react-native';
 const {
   View,
-  PropTypes
-} = React;
+} = ReactNative;
 
 const ACTION_TYPES = {
   onPress: 'press',

--- a/src/driver.js
+++ b/src/driver.js
@@ -1,6 +1,7 @@
-import React from 'react-native'
+import React from 'react'
 import Rx from 'rx'
-const {AppRegistry, View} = React
+import ReactNative from 'react-native';
+const {AppRegistry, View} = ReactNative;
 
 const BACK_ACTION = '@@back';
 const backHandler = new Rx.Subject


### PR DESCRIPTION
Requiring React API from react-native is deprecated in RN 0.25 or higher.